### PR TITLE
support "args" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ sak version v0.0.3
 
 ## Subcommands
 
+### `args` - Shows arguments given
+
+Synopsis: `args [ARGUMENTS]`
+
+Prints the number of arguments on STDERR, followed by a possibly colored "dump"
+of each given argument on STDOUT. It highlights escape, backslash, space, tab,
+newline and return carriage.
+Accepts no options other than --help.
+
 ### `csv2md` - Converts a CSV to MarkDown
 
 Synopsis: `csv2md [INPUT_FILE|-] [OUTPUT_FILE|-]`

--- a/args.go
+++ b/args.go
@@ -48,3 +48,80 @@ func IOArgs(args []string) (io.Reader, io.Writer) {
 	}
 	return r, w
 }
+
+var replacementRunesColored = map[rune][]rune{
+	'\\':   []rune("\x1b[31m\\\\\x1b[0m"),
+	' ':    []rune("\x1b[30;46m\\ \x1b[0m"),
+	'\t':   []rune("\x1b[30;44m\\t\x1b[0m"),
+	'\n':   []rune("\x1b[30;45m\\n\x1b[0m"),
+	'\r':   []rune("\x1b[30;45m\\r\x1b[0m"),
+	'\x1b': []rune("\x1b[32;42m\\e\x1b[0m"),
+}
+
+var replacementRunesPlain = map[rune][]rune{
+	'\\':   []rune("\\\\"),
+	' ':    []rune("\\ "),
+	'\t':   []rune("\\t"),
+	'\n':   []rune("\\n"),
+	'\r':   []rune("\\r"),
+	'\x1b': []rune("\\e"),
+}
+
+// automatically turn colors on/off depending on the circumstances in which
+// we're being called.
+func getWantsColors() bool {
+	wantsColors := false
+	// If STDOUT is a terminal, we can have colors.
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+		wantsColors = true
+	}
+	// If the user's specifically requesting no colors from any application, we
+	// should honor their choice.
+	if os.Getenv("NO_COLOR") != "" {
+		wantsColors = false
+	}
+	// If the user's specifically requesting no colors from THIS application, we
+	// should honor their choice, too.
+	if os.Getenv("SAK_NO_COLOR") != "" {
+		wantsColors = false
+	}
+	// A dumb terminal should never show colors.
+	if os.Getenv("TERM") == "dumb" {
+		wantsColors = false
+	}
+	return wantsColors
+}
+
+func argQuote(arg string, wantsColors bool) string {
+	argRunes := []rune(arg)
+	newRunes := make([]rune, 0)
+	replacementRunes := replacementRunesColored
+	if !wantsColors {
+		replacementRunes = replacementRunesPlain
+	}
+	for _, argRune := range argRunes {
+		rs, ok := replacementRunes[argRune]
+		if ok {
+			for _, r := range rs {
+				newRunes = append(newRunes, r)
+			}
+		} else {
+			newRunes = append(newRunes, argRune)
+		}
+	}
+	return string(newRunes)
+}
+
+// ShowArgs is the command that shows all arguments given to the program
+func ShowArgs(args []string) {
+	wantsColors := getWantsColors()
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "%d ARGV.\n", len(args))
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%d ARGV:\n", len(args))
+	fmtOutput := fmt.Sprintf("%%-%dd\t%%s\n", len(fmt.Sprintf("%d", len(args))))
+	for i, v := range args {
+		fmt.Printf(fmtOutput, i+1, argQuote(v, wantsColors))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,11 @@ Defaults to getting input from STDIN and giving output to STDOUT.
 You can specify "-" for either INPUT_FILE or OUTPUT_FILE to mean STDIN and STDOUT,
 respectively.
 Accepts no options other than --help.`},
+	"args": subcommand{ShowArgs, "Shows arguments given", "args [ARGUMENTS]",
+		`Prints the number of arguments on STDERR, followed by a possibly colored "dump"
+of each given argument on STDOUT. It highlights escape, backslash, space, tab,
+newline and return carriage.
+Accepts no options other than --help.`},
 }
 
 // ShowVersion shows the version of this tool.


### PR DESCRIPTION
... which is a migration of a Perl script I had lying around for ages, which "pretty prints" the arguments given to it.

Very helpful when debugging things like xargs-based pipelines.

DWIMs w/regards to whether to color output or not.