### PR TITLE
repo: better/neater readme

### DIFF
--- a/.dev/update-readme
+++ b/.dev/update-readme
@@ -87,7 +87,22 @@ sub subcommands_to_readme {
         push @lines, sprintf 'Synopsis: `%s`',
             $subcommands{$subcommand}{synopsis};
         push @lines, '';
-        push @lines, $subcommands{$subcommand}{full_description};
+        my $desc = $subcommands{$subcommand}{full_description};
+        my @desc_lines = split /\n/xms, $desc;
+        for my $i (0..$#desc_lines) {
+            my $line = $desc_lines[$i];
+            $line =~ s!\bDWIMs\b!dwims!xmsg;            # DWIMs -> dwims
+            $line =~ s!([A-Z][A-Z_-]{2,})!`$1`!xmsg;    # OUTPUT_FILE -> `OUTPUT_FILE`
+            $line =~ s!([^"])"([^"]+)"!$1`$2`!xmsg;     # "-" -> `-`
+            $line =~ s!""([^"]+)""!"$1"!xmsg;           # ""describes""- -> "describes"
+            $line =~ s!(\s)(--[a-z]+)!$1`$2`!xmsg       # --output-file -> `--output-file`
+                if $line !~ m!\A\s{4}!xms;
+            $line =~ s!(\\x[^ \)]+)!`$1`!xmsg;          # \x00 -> `x00`
+            $line =~ s!\bdwims\b!DWIMs!xmsg;            # dwims -> DWIMs
+            $line =~ s!\b(0x[a-f0-9]{2})\b!`$1`!xmsg;   # 0x00 -> `0x00`
+            push @lines, $line =~ m!\A`?[A-Z]!xms && $i > 0 ? "\n$line" : $line;
+            push @lines, '' if $line eq 'Options:';
+        }
     }
     push @lines, '';
     for (@lines) {

--- a/README.md
+++ b/README.md
@@ -44,55 +44,65 @@ sak version v0.0.9
 
 Synopsis: `args [ARGUMENTS]`
 
-Prints the number of arguments on STDERR, followed by a possibly colored "dump"
-of each given argument on STDOUT. It highlights escape, backslash, space, tab,
+Prints the number of arguments on `STDERR`, followed by a possibly colored "dump"
+of each given argument on `STDOUT`. It highlights escape, backslash, space, tab,
 newline and return carriage.
-If an argument contains non-basic runes (outside of 0x20-0x7e, 0x09, 0x0a, 0x0d
-and 0x1b, which are highlighted), it spits out one line per rune that comprises
+
+If an argument contains non-basic runes (outside of `0x20`-`0x7e`, `0x09`, `0x0a`, `0x0d`
+and `0x1b`, which are highlighted), it spits out one line per rune that comprises
 the full string argument, and "describes" them, showing its decimal and hex
 values, its name, and its properties.
-Accepts no options other than --help.
+
+Accepts no options other than `--help`.
 
 ### `csv2md` - Converts a CSV to MarkDown
 
 Synopsis: `csv2md [INPUT_FILE|-] [OUTPUT_FILE|-]`
 
-Converts a CSV file into a MarkDown file. Defaults to getting input from STDIN
-and giving output to STDOUT. You can specify "-" for either INPUT_FILE or
-OUTPUT_FILE to mean STDIN and STDOUT, respectively.
-Accepts no options other than --help.
+Converts a `CSV` file into a MarkDown file. Defaults to getting input from `STDIN`
+and giving output to `STDOUT`. You can specify `-` for either `INPUT_FILE` or
+
+`OUTPUT_FILE` to mean `STDIN` and `STDOUT`, respectively.
+
+Accepts no options other than `--help`.
 
 ### `csv2tsv` - Converts a CSV into a TSV
 
 Synopsis: `csv2tsv [INPUT_FILE|-] [OUTPUT_FILE|-]`
 
-Converts a CSV file into a TSV file. Defaults to getting input from STDIN
-and giving output to STDOUT. You can specify "-" for either INPUT_FILE or
-OUTPUT_FILE to mean STDIN and STDOUT, respectively.
-Accepts no options other than --help.
+Converts a `CSV` file into a `TSV` file. Defaults to getting input from `STDIN`
+and giving output to `STDOUT`. You can specify `-` for either `INPUT_FILE` or
+
+`OUTPUT_FILE` to mean `STDIN` and `STDOUT`, respectively.
+
+Accepts no options other than `--help`.
 
 ### `rune` - Shows runes matching the arguments
 
 Synopsis: `rune [OPTIONS] ARGUMENT [ARGUMENT+]`
 
-Prints/describes the Unicode runes matching ARGUMENT. Optionally shows them.
+Prints/describes the Unicode runes matching `ARGUMENT`. Optionally shows them.
+
 Uses the "fixed" rune descriptions for control characters, and support font
 awesome runes as well.
-ARGUMENT can be one of:
-- a string, or a string starting with "+", is used to restrict runes to the ones
-  which contain ARGUMENT in their description, case insensitively
-- a string starting with "-", excludes runes whose description matches, case
-  insensitively, ARGUMENT
-- a string starting with "/" or with "+/", the ARGUMENT is taken as a case
+
+`ARGUMENT` can be one of:
+- a string, or a string starting with `+`, is used to restrict runes to the ones
+  which contain `ARGUMENT` in their description, case insensitively
+- a string starting with `-`, excludes runes whose description matches, case
+  insensitively, `ARGUMENT`
+- a string starting with `/` or with `+/`, the `ARGUMENT` is taken as a case
   insensitive regular expression and runes are output if they match it
-- a string starting with "-/", the ARGUMENT is taken as a case insensitive
+- a string starting with `-/`, the `ARGUMENT` is taken as a case insensitive
   regular expression, and runes are excluded if they match it
-- If only one ARGUMENT is given, and it matches a decimal number, then it
+- If only one `ARGUMENT` is given, and it matches a decimal number, then it
   displays information about the rune identified by that decimal number.
-- If only one ARGUMENT is given, and it matches a hexadecimal number (starting
-  with the string "0x"), then it displays information about the rune identified
+- If only one `ARGUMENT` is given, and it matches a hexadecimal number (starting
+  with the string `0x`), then it displays information about the rune identified
   by that hexadecimal number.
+
 Options:
+
     --help    Shows this help page
     --show    Shows the rune character as well as its description
 
@@ -100,58 +110,74 @@ Options:
 
 Synopsis: `runes ARGUMENT [ARGUMENT+]`
 
-Prints/describes the Unicode runes contained in each ARGUMENT.
+Prints/describes the Unicode runes contained in each `ARGUMENT`.
+
 Uses the "fixed" rune descriptions for control characters, and supports font
 awesome runes as well.  Useful to identify presence of combining characters.
-Accepts no options other than --help.
+
+Accepts no options other than `--help`.
 
 ### `since` - Shows days, months etc between dates
 
 Synopsis: `since START_DATE [END_DATE|TODAY]`
 
-Prints the amount of days, weeks, months years between START_DATE and END_DATE.
-END_DATE defaults to today's date. Dates need to be given in YYYY-MM-DD format.
-DWIMs if END_DATE is <= START_DATE.
-Accepts no options other than --help.
+Prints the amount of days, weeks, months years between `START_DATE` and `END_DATE`.
+
+`END_DATE` defaults to today's date. Dates need to be given in `YYYY-MM-DD` format.
+
+DWIMs if `END_DATE` is <= `START_DATE`.
+
+Accepts no options other than `--help`.
 
 ### `stripansi` - strips ansi from input
 
 Synopsis: `stripansi [INPUT_FILE|-] [OUTPUT_FILE|-]`
 
-Strips ANSI strings (i.e. \x1b[...m) from INPUT_FILE, and writes to OUTPUT_FILE.
-Defaults to getting input from STDIN and giving output to STDOUT.
-You can specify "-" for either INPUT_FILE or OUTPUT_FILE to mean STDIN and STDOUT,
+Strips `ANSI` strings (i.e. `\x1b[...m`) from `INPUT_FILE`, and writes to `OUTPUT_FILE`.
+
+Defaults to getting input from `STDIN` and giving output to `STDOUT`.
+
+You can specify `-` for either `INPUT_FILE` or `OUTPUT_FILE` to mean `STDIN` and `STDOUT`,
 respectively.
-Accepts no options other than --help.
+
+Accepts no options other than `--help`.
 
 ### `tsv2csv` - Converts a TSV into a CSV
 
 Synopsis: `tsv2csv [INPUT_FILE|-] [OUTPUT_FILE|-]`
 
-Converts a TSV file into a CSV file. Defaults to getting input from STDIN
-and giving output to STDOUT. You can specify "-" for either INPUT_FILE or
-OUTPUT_FILE to mean STDIN and STDOUT, respectively.
-Accepts no options other than --help.
+Converts a `TSV` file into a `CSV` file. Defaults to getting input from `STDIN`
+and giving output to `STDOUT`. You can specify `-` for either `INPUT_FILE` or
+
+`OUTPUT_FILE` to mean `STDIN` and `STDOUT`, respectively.
+
+Accepts no options other than `--help`.
 
 ### `tsv2md` - Converts a TSV to MarkDown
 
 Synopsis: `tsv2md [INPUT_FILE|-] [OUTPUT_FILE|-]`
 
-Converts a TSV file into a MarkDown file. Defaults to getting input from STDIN
-and giving output to STDOUT. You can specify "-" for either INPUT_FILE or
-OUTPUT_FILE to mean STDIN and STDOUT, respectively.
-Accepts no options other than --help.
+Converts a `TSV` file into a MarkDown file. Defaults to getting input from `STDIN`
+and giving output to `STDOUT`. You can specify `-` for either `INPUT_FILE` or
+
+`OUTPUT_FILE` to mean `STDIN` and `STDOUT`, respectively.
+
+Accepts no options other than `--help`.
 
 ### `xsv2md` - Converts a xSV to MarkDown
 
 Synopsis: `xsv2md SEPARATOR [INPUT_FILE|-] [OUTPUT_FILE|-]`
 
-Converts a xSV file into a MarkDown file. Requires a SEPARATOR to be given.
-The SEPARATOR should be one-character, like $'\t' or ','.
-Defaults to getting input from STDIN and giving output to STDOUT.
-You can specify "-" for either INPUT_FILE or OUTPUT_FILE to mean STDIN and STDOUT,
+Converts a xSV file into a MarkDown file. Requires a `SEPARATOR` to be given.
+
+The `SEPARATOR` should be one-character, like $'\t' or ','.
+
+Defaults to getting input from `STDIN` and giving output to `STDOUT`.
+
+You can specify `-` for either `INPUT_FILE` or `OUTPUT_FILE` to mean `STDIN` and `STDOUT`,
 respectively.
-Accepts no options other than --help.
+
+Accepts no options other than `--help`.
 
 ## LICENSE
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // Version contains the binary version. This is added at build time.
@@ -46,17 +47,17 @@ You can specify "-" for either INPUT_FILE or OUTPUT_FILE to mean STDIN and STDOU
 respectively.
 Accepts no options other than --help.`},
 	"args": {ShowArgs, "Shows arguments given", "args [ARGUMENTS]",
-		`Prints the number of arguments on STDERR, followed by a possibly colored "dump"
+		`Prints the number of arguments on STDERR, followed by a possibly colored ""dump""
 of each given argument on STDOUT. It highlights escape, backslash, space, tab,
 newline and return carriage.
 If an argument contains non-basic runes (outside of 0x20-0x7e, 0x09, 0x0a, 0x0d
 and 0x1b, which are highlighted), it spits out one line per rune that comprises
-the full string argument, and "describes" them, showing its decimal and hex
+the full string argument, and ""describes"" them, showing its decimal and hex
 values, its name, and its properties.
 Accepts no options other than --help.`},
 	"rune": {Rune, "Shows runes matching the arguments", "rune [OPTIONS] ARGUMENT [ARGUMENT+]",
 		`Prints/describes the Unicode runes matching ARGUMENT. Optionally shows them.
-Uses the "fixed" rune descriptions for control characters, and support font
+Uses the ""fixed"" rune descriptions for control characters, and support font
 awesome runes as well.
 ARGUMENT can be one of:
 - a string, or a string starting with "+", is used to restrict runes to the ones
@@ -77,7 +78,7 @@ Options:
     --show    Shows the rune character as well as its description`},
 	"runes": {Runes, "Shows runes contained in the string arguments", "runes ARGUMENT [ARGUMENT+]",
 		`Prints/describes the Unicode runes contained in each ARGUMENT.
-Uses the "fixed" rune descriptions for control characters, and supports font
+Uses the ""fixed"" rune descriptions for control characters, and supports font
 awesome runes as well.  Useful to identify presence of combining characters.
 Accepts no options other than --help.`},
 	"stripansi": {StripANSI, "strips ansi from input", "stripansi [INPUT_FILE|-] [OUTPUT_FILE|-]",
@@ -151,7 +152,7 @@ func main() {
 		}
 		if arg == "--help" || arg == "-help" {
 			fmt.Printf("Synopsis: %s\n", sc.Synopsis)
-			fmt.Println(sc.FullDescription)
+			fmt.Println(strings.Replace(sc.FullDescription, "\"\"", "\"", -1))
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
... by "enhancing" the logic that creates markdown from the golang strings.

Also, use double double quotes for keeping the string in single double quotes on both markdown and help output; "normal" double quotes are instead translated into backticks for markdown output.